### PR TITLE
Fix/hostname crash net9

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ using WatsonWebserver;
 static void Main(string[] args)
 {
   WebserverSettings settings = new WebserverSettings("127.0.0.1", 9000);
-  WebserverBase server = new WebserverBase(settings, DefaultRoute);
+  WebserverBase server = new Webserver(settings, DefaultRoute);
   server.Start();
   Console.ReadLine();
 }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ I'd like to extend a special thanks to those that have helped make Watson Webser
 - @MartyIX @pocsuka @orinem @deathbull @binozo @panboy75 @iain-cyborn @gamerhost31 
 - @nhaberl @grgouala @sapurtcomputer30 @winkmichael @sqlnew @SaintedPsycho @Return25 
 - @marcussacana @samisil @Jump-Suit @ChZhongPengCheng33 @bobaoapae @rodgers-r 
-- @john144 @zedle @GitHubProUser67 @bemoty @bemon @nomadeon
+- @john144 @zedle @GitHubProUser67 @bemoty @bemon @nomadeon @Infiziert90
 
 ## Watson vs Watson.Lite
 
@@ -50,6 +50,7 @@ Watson.Lite is generally less performant than Watson, because the HTTP implement
   - Watson.Lite uses a TCP listener; your server must be started with an IP address, not a hostname
   - The HTTP HOST header does not need to match, since the listener must be defined by IP address
   - For SSL, the certificate filename, filename and password, or `X509Certificate2` must be supplied
+  - When a request body is present, certain browsers may require that you fully read the request body server-side before redirecting or responding to the request
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ I'd like to extend a special thanks to those that have helped make Watson Webser
 - @MartyIX @pocsuka @orinem @deathbull @binozo @panboy75 @iain-cyborn @gamerhost31 
 - @nhaberl @grgouala @sapurtcomputer30 @winkmichael @sqlnew @SaintedPsycho @Return25 
 - @marcussacana @samisil @Jump-Suit @ChZhongPengCheng33 @bobaoapae @rodgers-r 
-- @john144 @zedle @GitHubProUser67 @bemoty @bemon @nomadeon @Infiziert90
+- @john144 @zedle @GitHubProUser67 @bemoty @bemon @nomadeon @Infiziert90 @kyoybs 
 
 ## Watson vs Watson.Lite
 

--- a/src/WatsonWebserver.Core/UrlDetails.cs
+++ b/src/WatsonWebserver.Core/UrlDetails.cs
@@ -25,6 +25,53 @@
         #region Public-Members
 
         /// <summary>
+        /// URI.  This value may be null based on how the UrlDetails object was initialized.
+        /// </summary>
+        public Uri Uri
+        {
+            get
+            {
+                return _Uri;
+            }
+        }
+
+        /// <summary>
+        /// Scheme name for the URI.
+        /// </summary>
+        public string Scheme
+        {
+            get
+            {
+                if (_Uri != null) return _Uri.Scheme;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Host name from the URI.
+        /// </summary>
+        public string Host
+        {
+            get
+            {
+                if (_Uri != null) return _Uri.Host;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Port number from the URI.
+        /// </summary>
+        public int? Port
+        {
+            get
+            {
+                if (_Uri != null) return _Uri.Port;
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Full URL.
         /// </summary>
         public string Full { get; set; } = null;
@@ -101,10 +148,11 @@
             }
         }
 
-        #endregion
+        #endregion 
 
         #region Private-Members
-        
+
+        private Uri _Uri = null;
         private NameValueCollection _Parameters = new NameValueCollection(StringComparer.InvariantCultureIgnoreCase);
 
         #endregion
@@ -127,6 +175,8 @@
         public UrlDetails(string fullUrl, string rawUrl)
         {
             if (String.IsNullOrEmpty(rawUrl)) throw new ArgumentNullException(nameof(rawUrl));
+
+            _Uri = new Uri(fullUrl);
 
             Full = fullUrl;
             RawWithQuery = rawUrl;

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.csproj
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.10</Version>
+		<Version>6.3.12</Version>
 		<Description>Core library for Watson and Watson.Lite; simple, fast, async C# web servers for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.csproj
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.9</Version>
+		<Version>6.3.10</Version>
 		<Description>Core library for Watson and Watson.Lite; simple, fast, async C# web servers for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
@@ -1438,6 +1438,26 @@
             URL details.
             </summary>
         </member>
+        <member name="P:WatsonWebserver.Core.UrlDetails.Uri">
+            <summary>
+            URI.  This value may be null based on how the UrlDetails object was initialized.
+            </summary>
+        </member>
+        <member name="P:WatsonWebserver.Core.UrlDetails.Scheme">
+            <summary>
+            Scheme name for the URI.
+            </summary>
+        </member>
+        <member name="P:WatsonWebserver.Core.UrlDetails.Host">
+            <summary>
+            Host name from the URI.
+            </summary>
+        </member>
+        <member name="P:WatsonWebserver.Core.UrlDetails.Port">
+            <summary>
+            Port number from the URI.
+            </summary>
+        </member>
         <member name="P:WatsonWebserver.Core.UrlDetails.Full">
             <summary>
             Full URL.

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
@@ -1968,6 +1968,11 @@
             Be sure to set Events.Logger in order to receive debug messages.
             </summary>
         </member>
+        <member name="P:WatsonWebserver.Core.WebserverSettings.UseMachineHostname">
+            <summary>
+            When true, the machine's hostname will be used instead of the value specified in Hostname.
+            </summary>
+        </member>
         <member name="M:WatsonWebserver.Core.WebserverSettings.#ctor">
             <summary>
             Webserver settings.

--- a/src/WatsonWebserver.Core/WebserverBase.cs
+++ b/src/WatsonWebserver.Core/WebserverBase.cs
@@ -6,9 +6,10 @@
     using System.Linq;
     using System.Net;
     using System.Reflection;
+    using System.Text.Json.Serialization;
+    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Webserver base.
@@ -198,6 +199,74 @@
         #endregion
 
         #region Private-Members
+        /// <summary>
+        /// Robustly retrieves and sanitizes a valid hostname for the local machine
+        /// by trying several strategies in order of preference.
+        /// This method is safe to use on all platforms, including iOS and Android.
+        /// </summary>
+        /// <returns>An RFC-compliant valid hostname, with a final fallback to "localhost".</returns>
+        protected static string GetBestLocalHostName()
+        {
+            string sanitizedHostName;
+
+            // Attempt 1: Dns.GetHostName() - The best choice for network identity.
+            try
+            {
+                sanitizedHostName = SanitizeHostName(Dns.GetHostName());
+                if (!string.IsNullOrEmpty(sanitizedHostName))
+                {
+                    return sanitizedHostName;
+                }
+            }
+            catch { /* Ignore and move to fallback */ }
+
+            // Attempt 2: Environment.MachineName - A solid backup that returns the device name.
+            try
+            {
+                sanitizedHostName = SanitizeHostName(Environment.MachineName);
+                if (!string.IsNullOrEmpty(sanitizedHostName))
+                {
+                    return sanitizedHostName;
+                }
+            }
+            catch { /* Ignore and move to fallback */ }
+
+            return "localhost";
+        }
+
+        /// <summary>
+        /// Converts a string into a valid RFC 1123 hostname.
+        /// It removes invalid characters, converts to lowercase, and handles hyphens.
+        /// </summary>
+        /// <param name="potentialName">The name to sanitize.</param>
+        /// <returns>A valid hostname, or null if the string contains no valid characters.</returns>
+        protected static string SanitizeHostName(string potentialName)
+        {
+            if (string.IsNullOrWhiteSpace(potentialName))
+            {
+                return null;
+            }
+
+            // 1. Convert to lowercase for consistency.
+            string sanitized = potentialName.ToLowerInvariant();
+
+            // 2. Replace spaces and other common separators with a hyphen.
+            sanitized = Regex.Replace(sanitized, @"[\s_.]+", "-");
+
+            // 3. Remove all characters that are not letters, numbers, or hyphens.
+            sanitized = Regex.Replace(sanitized, @"[^a-z0-9-]", "");
+
+            // 4. Remove any leading or trailing hyphens.
+            sanitized = sanitized.Trim('-');
+
+            // 5. If nothing is left after cleaning, the name is invalid.
+            if (string.IsNullOrEmpty(sanitized))
+            {
+                return null;
+            }
+
+            return sanitized;
+        }
 
         #endregion
     }

--- a/src/WatsonWebserver.Core/WebserverSettings.cs
+++ b/src/WatsonWebserver.Core/WebserverSettings.cs
@@ -176,6 +176,8 @@
             if (String.IsNullOrEmpty(hostname)) hostname = "localhost";
             if (port < 0) throw new ArgumentOutOfRangeException(nameof(port));
 
+            if (hostname.Equals("::")) hostname = "[::]";
+
             _Ssl.Enable = ssl;
             _Hostname = hostname;
             _Port = port;

--- a/src/WatsonWebserver.Core/WebserverSettings.cs
+++ b/src/WatsonWebserver.Core/WebserverSettings.cs
@@ -141,6 +141,22 @@
             }
         }
 
+        /// <summary>
+        /// When true, the machine's hostname will be used instead of the value specified in Hostname.
+        /// </summary>
+        public bool UseMachineHostname
+        {
+            get
+            {
+                if (Hostname == "*" || Hostname == "+") return true;
+                return _UseMachineHostname;
+            }
+            set
+            {
+                _UseMachineHostname = (Hostname == "*" || Hostname == "+") || value;
+            }
+        }
+
         #endregion
 
         #region Private-Members
@@ -152,6 +168,7 @@
         private AccessControlManager _AccessControl = new AccessControlManager(AccessControlMode.DefaultPermit);
         private DebugSettings _Debug = new DebugSettings();
         private HeaderSettings _Headers = new HeaderSettings();
+        private bool _UseMachineHostname = false;
 
         #endregion
 

--- a/src/WatsonWebserver.Lite/HttpRequest.cs
+++ b/src/WatsonWebserver.Lite/HttpRequest.cs
@@ -452,6 +452,10 @@
                         ms.Write(buffer, 0, read);
                         bytesRemaining -= read;
                     }
+                    else
+                    {
+                        throw new IOException("Connection closed before reading to the end of the stream.");
+                    }
                 }
 
                 byte[] ret = ms.ToArray();

--- a/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
+++ b/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.9</Version>
+		<Version>6.3.10</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.  Watson.Lite has no dependency on http.sys.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 		<Authors>Joel Christner</Authors>
@@ -29,7 +29,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CavemanTcp" Version="2.0.9" />
-		<PackageReference Include="Watson.Core" Version="6.3.9" />
+		<PackageReference Include="Watson.Core" Version="6.3.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
+++ b/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.10</Version>
+		<Version>6.3.12</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.  Watson.Lite has no dependency on http.sys.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 		<Authors>Joel Christner</Authors>
@@ -29,7 +29,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CavemanTcp" Version="2.0.9" />
-		<PackageReference Include="Watson.Core" Version="6.3.10" />
+		<PackageReference Include="Watson.Core" Version="6.3.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver.Lite/WatsonWebserver.Lite.xml
+++ b/src/WatsonWebserver.Lite/WatsonWebserver.Lite.xml
@@ -308,5 +308,21 @@
             Stop accepting new connections.
             </summary>
         </member>
+        <member name="M:WatsonWebserver.Lite.WebserverLite.GetBestLocalHostName">
+            <summary>
+            Robustly retrieves and sanitizes a valid hostname for the local machine
+            by trying several strategies in order of preference.
+            This method is safe to use on all platforms, including iOS and Android.
+            </summary>
+            <returns>An RFC-compliant valid hostname, with a final fallback to "localhost".</returns>
+        </member>
+        <member name="M:WatsonWebserver.Lite.WebserverLite.SanitizeHostName(System.String)">
+            <summary>
+            Converts a string into a valid RFC 1123 hostname.
+            It removes invalid characters, converts to lowercase, and handles hyphens.
+            </summary>
+            <param name="potentialName">The name to sanitize.</param>
+            <returns>A valid hostname, or null if the string contains no valid characters.</returns>
+        </member>
     </members>
 </doc>

--- a/src/WatsonWebserver.Lite/Webserver.cs
+++ b/src/WatsonWebserver.Lite/Webserver.cs
@@ -9,6 +9,7 @@
     using System.Reflection;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
+    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
     using CavemanTcp;
@@ -69,7 +70,20 @@
             if (settings == null) settings = new WebserverSettings(); 
 
             Settings = settings;
-            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = settings.Hostname + ":" + settings.Port;
+
+            // TODO: Use the following to determine the hostname to use in the Host when you will deploy the Watson.Core changes in order to use 
+            // the settings.UseMachineHostname option.
+            // string hostnameForHeader = settings.UseMachineHostname ? GetBestLocalHostName() : settings.Hostname;
+
+            // TODO: this is the current behavior, which does not use the UseMachineHostname option and it is limited to just checking for * or +
+            string hostnameForHeader = settings.Hostname;
+            if (settings.Hostname == "*" || settings.Hostname == "+")
+            {
+                hostnameForHeader = GetBestLocalHostName();
+            }
+
+            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = hostnameForHeader + ":" + settings.Port;
+
             Routes = new WebserverRoutes(Settings, defaultRoute);
 
             _Header = "[Webserver " + Settings.Prefix + "] ";
@@ -157,6 +171,78 @@
 
         #region Private-Methods
 
+        //TODO: Consider move GetBestLocalHostName and SanitizeHostName to Watson.Core 
+        //      to avoid DRY violations.
+
+        /// <summary>
+        /// Robustly retrieves and sanitizes a valid hostname for the local machine
+        /// by trying several strategies in order of preference.
+        /// This method is safe to use on all platforms, including iOS and Android.
+        /// </summary>
+        /// <returns>An RFC-compliant valid hostname, with a final fallback to "localhost".</returns>
+        private static string GetBestLocalHostName()
+        {
+            string sanitizedHostName;
+
+            // Attempt 1: Dns.GetHostName() - The best choice for network identity.
+            try
+            {
+                sanitizedHostName = SanitizeHostName(Dns.GetHostName());
+                if (!string.IsNullOrEmpty(sanitizedHostName))
+                {
+                    return sanitizedHostName;
+                }
+            }
+            catch { /* Ignore and move to fallback */ }
+
+            // Attempt 2: Environment.MachineName - A solid backup that returns the device name.
+            try
+            {
+                sanitizedHostName = SanitizeHostName(Environment.MachineName);
+                if (!string.IsNullOrEmpty(sanitizedHostName))
+                {
+                    return sanitizedHostName;
+                }
+            }
+            catch { /* Ignore and move to fallback */ }
+
+            return "localhost";
+        }
+
+        /// <summary>
+        /// Converts a string into a valid RFC 1123 hostname.
+        /// It removes invalid characters, converts to lowercase, and handles hyphens.
+        /// </summary>
+        /// <param name="potentialName">The name to sanitize.</param>
+        /// <returns>A valid hostname, or null if the string contains no valid characters.</returns>
+        private static string SanitizeHostName(string potentialName)
+        {
+            if (string.IsNullOrWhiteSpace(potentialName))
+            {
+                return null;
+            }
+
+            // 1. Convert to lowercase for consistency.
+            string sanitized = potentialName.ToLowerInvariant();
+
+            // 2. Replace spaces and other common separators with a hyphen.
+            sanitized = Regex.Replace(sanitized, @"[\s_.]+", "-");
+
+            // 3. Remove all characters that are not letters, numbers, or hyphens.
+            sanitized = Regex.Replace(sanitized, @"[^a-z0-9-]", "");
+
+            // 4. Remove any leading or trailing hyphens.
+            sanitized = sanitized.Trim('-');
+
+            // 5. If nothing is left after cleaning, the name is invalid.
+            if (string.IsNullOrEmpty(sanitized))
+            {
+                return null;
+            }
+
+            return sanitized;
+        }
+        
         private void InitializeServer(string hostname, int port)
         {
             if (!Settings.Ssl.Enable)

--- a/src/WatsonWebserver/WatsonWebserver.csproj
+++ b/src/WatsonWebserver/WatsonWebserver.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.9</Version>
+		<Version>6.3.10</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 		<Authors>Joel Christner</Authors>
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Watson.Core" Version="6.3.9" />
+	  <PackageReference Include="Watson.Core" Version="6.3.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver/WatsonWebserver.csproj
+++ b/src/WatsonWebserver/WatsonWebserver.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.10</Version>
+		<Version>6.3.12</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 		<Authors>Joel Christner</Authors>
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Watson.Core" Version="6.3.10" />
+	  <PackageReference Include="Watson.Core" Version="6.3.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver/Webserver.cs
+++ b/src/WatsonWebserver/Webserver.cs
@@ -6,12 +6,13 @@
     using System.Linq;
     using System.Net;
     using System.Reflection;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using System.Text.Json.Serialization;
-    using WatsonWebserver.Core;
     using System.Runtime.InteropServices;
     using System.Text;
+    using System.Text.Json.Serialization;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using WatsonWebserver.Core;
 
     /// <summary>
     /// Watson webserver.
@@ -69,7 +70,20 @@
             if (settings == null) settings = new WebserverSettings();
 
             Settings = settings;
-            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = settings.Hostname + ":" + settings.Port;
+
+            // TODO: Use the following to determine the hostname to use in the Host when you will deploy the Watson.Core changes in order to use 
+            // the settings.UseMachineHostname option.
+            // string hostnameForHeader = settings.UseMachineHostname ? GetBestLocalHostName() : settings.Hostname;
+
+            // TODO: this is the current behavior, which does not use the UseMachineHostname option and it is limited to just checking for * or +
+            string hostnameForHeader = settings.Hostname;
+            if (settings.Hostname == "*" || settings.Hostname == "+")
+            {
+                hostnameForHeader = GetBestLocalHostName();
+            }
+
+            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = hostnameForHeader + ":" + settings.Port;
+
             Routes.Default = defaultRoute;
 
             _Header = "[Webserver " + Settings.Prefix + "] ";
@@ -157,6 +171,78 @@
         #endregion
 
         #region Private-Methods
+
+        //TODO: Consider move GetBestLocalHostName and SanitizeHostName to Watson.Core 
+        //      to avoid DRY violations.
+
+        /// <summary>
+        /// Robustly retrieves and sanitizes a valid hostname for the local machine
+        /// by trying several strategies in order of preference.
+        /// This method is safe to use on all platforms, including iOS and Android.
+        /// </summary>
+        /// <returns>An RFC-compliant valid hostname, with a final fallback to "localhost".</returns>
+        private static string GetBestLocalHostName()
+        {
+            string sanitizedHostName;
+
+            // Attempt 1: Dns.GetHostName() - The best choice for network identity.
+            try
+            {
+                sanitizedHostName = SanitizeHostName(Dns.GetHostName());
+                if (!string.IsNullOrEmpty(sanitizedHostName))
+                {
+                    return sanitizedHostName;
+                }
+            }
+            catch { /* Ignore and move to fallback */ }
+
+            // Attempt 2: Environment.MachineName - A solid backup that returns the device name.
+            try
+            {
+                sanitizedHostName = SanitizeHostName(Environment.MachineName);
+                if (!string.IsNullOrEmpty(sanitizedHostName))
+                {
+                    return sanitizedHostName;
+                }
+            }
+            catch { /* Ignore and move to fallback */ }
+
+            return "localhost";
+        }
+
+        /// <summary>
+        /// Converts a string into a valid RFC 1123 hostname.
+        /// It removes invalid characters, converts to lowercase, and handles hyphens.
+        /// </summary>
+        /// <param name="potentialName">The name to sanitize.</param>
+        /// <returns>A valid hostname, or null if the string contains no valid characters.</returns>
+        private static string SanitizeHostName(string potentialName)
+        {
+            if (string.IsNullOrWhiteSpace(potentialName))
+            {
+                return null;
+            }
+
+            // 1. Convert to lowercase for consistency.
+            string sanitized = potentialName.ToLowerInvariant();
+
+            // 2. Replace spaces and other common separators with a hyphen.
+            sanitized = Regex.Replace(sanitized, @"[\s_.]+", "-");
+
+            // 3. Remove all characters that are not letters, numbers, or hyphens.
+            sanitized = Regex.Replace(sanitized, @"[^a-z0-9-]", "");
+
+            // 4. Remove any leading or trailing hyphens.
+            sanitized = sanitized.Trim('-');
+
+            // 5. If nothing is left after cleaning, the name is invalid.
+            if (string.IsNullOrEmpty(sanitized))
+            {
+                return null;
+            }
+
+            return sanitized;
+        }
 
         /// <summary>
         /// Tear down the server and dispose of background workers.


### PR DESCRIPTION
This commit introduce a feature to set the default hostname to the machine hostname sanitized whenever the user sets the wildcard binding ("*","+") 
This feature fixes the issue in .net9 that causes socket hangup due to System.Net.Url exception for malformat hostname ("*","+" are not valid hostname caracters.
Please note that since projects have direct dependencies to Nuget deployed packages some TODOs have been set:
- logic to obtain the hostname and sanitize has been duplicated between WebServer and WebServer.Lite as the implementation from the base class in Core is not reachable from children projects.
- the use of machine hostname has been added to webserver settings to allow user to decide to use either in normal scenarios. This part should be activated as long as core is released.

Future improvements: the repository should directly reference the projects rather then rely on the nuget pachage. 
When package is created the whole packaging system knows that any reference to internal projects should be resolved over package manager and references are updated accordingly to .csproj. As Core project has the correct Nuget Package Id there is no need to force the Nuget in children. This feature might be there for other reasons so I have not touched it.