### PR TITLE
feat: Introduce UseMachineHostname for robust Host header handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ using WatsonWebserver;
 static void Main(string[] args)
 {
   WebserverSettings settings = new WebserverSettings("127.0.0.1", 9000);
-  WebserverBase server = new WebserverBase(settings, DefaultRoute);
+  WebserverBase server = new Webserver(settings, DefaultRoute);
   server.Start();
   Console.ReadLine();
 }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ I'd like to extend a special thanks to those that have helped make Watson Webser
 - @MartyIX @pocsuka @orinem @deathbull @binozo @panboy75 @iain-cyborn @gamerhost31 
 - @nhaberl @grgouala @sapurtcomputer30 @winkmichael @sqlnew @SaintedPsycho @Return25 
 - @marcussacana @samisil @Jump-Suit @ChZhongPengCheng33 @bobaoapae @rodgers-r 
-- @john144 @zedle @GitHubProUser67 @bemoty @bemon @nomadeon
+- @john144 @zedle @GitHubProUser67 @bemoty @bemon @nomadeon @Infiziert90
 
 ## Watson vs Watson.Lite
 
@@ -50,6 +50,7 @@ Watson.Lite is generally less performant than Watson, because the HTTP implement
   - Watson.Lite uses a TCP listener; your server must be started with an IP address, not a hostname
   - The HTTP HOST header does not need to match, since the listener must be defined by IP address
   - For SSL, the certificate filename, filename and password, or `X509Certificate2` must be supplied
+  - When a request body is present, certain browsers may require that you fully read the request body server-side before redirecting or responding to the request
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,47 @@ static async Task TestRoute(HttpContextBase ctx) =>
     await ctx.Response.Send("Hello from the test route!"); 
 ```
 
+## Hostname Handling for HTTP Responses
+
+To correctly handle the `Host` HTTP header, a new boolean property, `UseMachineHostname`, has been introduced in `WebserverSettings`. This is especially important when using wildcard bindings.
+
+-   **Wildcard Binding Behavior**: When `Hostname` is set to `*` or `+`, the server will **mandatorily** use the machine's actual hostname for the `Host` header in HTTP responses. This prevents `UriFormatException` on modern .NET runtimes. In this scenario, `UseMachineHostname` is forced to `true`.
+
+-   **Default Behavior**: For any other hostname (e.g., `localhost` or an IP address), this feature is **disabled by default**. The `Host` header will use the value specified in the `Hostname` setting.
+
+-   **Manual Activation**: You can force the use of the machine's hostname for any binding by setting `UseMachineHostname = true` in the settings.
+
+### Usage
+
+**Example 1: Using a Wildcard (Mandatory Machine Hostname)**
+
+```csharp
+// The server detects the wildcard and mandatorily uses the machine's hostname for the Host header.
+var server = new Server("*", 9000, false, DefaultRoute);
+server.Start();
+```
+
+**Example 2: Manually Enabling for a Specific Hostname**
+
+```csharp
+// By default, the Host header would be "localhost:9000".
+// By setting UseMachineHostname = true, we force it to use the machine's actual hostname.
+var settings = new WebserverSettings("localhost", 9000);
+settings.UseMachineHostname = true; 
+var server = new Server(settings, DefaultRoute);
+server.Start();
+```
+
+### Hostname Examples
+
+When `UseMachineHostname` is active, the retrieved hostname will vary depending on the operating system and network configuration. Here are some typical examples (after sanitization):
+
+-   **Windows**: `desktop-a1b2c3d`
+-   **macOS**: `marcos-macbook-pro.local`
+-   **Linux**: `ubuntu-server`
+-   **Android**: `pixel-7-pro`
+-   **iOS**: `marcos-iphone.local`
+
 ## Accessing from Outside Localhost
 
 ### Watson

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ I'd like to extend a special thanks to those that have helped make Watson Webser
 - @MartyIX @pocsuka @orinem @deathbull @binozo @panboy75 @iain-cyborn @gamerhost31 
 - @nhaberl @grgouala @sapurtcomputer30 @winkmichael @sqlnew @SaintedPsycho @Return25 
 - @marcussacana @samisil @Jump-Suit @ChZhongPengCheng33 @bobaoapae @rodgers-r 
-- @john144 @zedle @GitHubProUser67 @bemoty @bemon @nomadeon @Infiziert90
+- @john144 @zedle @GitHubProUser67 @bemoty @bemon @nomadeon @Infiziert90 @kyoybs 
 
 ## Watson vs Watson.Lite
 

--- a/src/WatsonWebserver.Core/UrlDetails.cs
+++ b/src/WatsonWebserver.Core/UrlDetails.cs
@@ -25,6 +25,53 @@
         #region Public-Members
 
         /// <summary>
+        /// URI.  This value may be null based on how the UrlDetails object was initialized.
+        /// </summary>
+        public Uri Uri
+        {
+            get
+            {
+                return _Uri;
+            }
+        }
+
+        /// <summary>
+        /// Scheme name for the URI.
+        /// </summary>
+        public string Scheme
+        {
+            get
+            {
+                if (_Uri != null) return _Uri.Scheme;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Host name from the URI.
+        /// </summary>
+        public string Host
+        {
+            get
+            {
+                if (_Uri != null) return _Uri.Host;
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Port number from the URI.
+        /// </summary>
+        public int? Port
+        {
+            get
+            {
+                if (_Uri != null) return _Uri.Port;
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Full URL.
         /// </summary>
         public string Full { get; set; } = null;
@@ -101,10 +148,11 @@
             }
         }
 
-        #endregion
+        #endregion 
 
         #region Private-Members
-        
+
+        private Uri _Uri = null;
         private NameValueCollection _Parameters = new NameValueCollection(StringComparer.InvariantCultureIgnoreCase);
 
         #endregion
@@ -127,6 +175,8 @@
         public UrlDetails(string fullUrl, string rawUrl)
         {
             if (String.IsNullOrEmpty(rawUrl)) throw new ArgumentNullException(nameof(rawUrl));
+
+            _Uri = new Uri(fullUrl);
 
             Full = fullUrl;
             RawWithQuery = rawUrl;

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.csproj
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.10</Version>
+		<Version>6.3.12</Version>
 		<Description>Core library for Watson and Watson.Lite; simple, fast, async C# web servers for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.csproj
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.9</Version>
+		<Version>6.3.10</Version>
 		<Description>Core library for Watson and Watson.Lite; simple, fast, async C# web servers for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
@@ -1438,6 +1438,26 @@
             URL details.
             </summary>
         </member>
+        <member name="P:WatsonWebserver.Core.UrlDetails.Uri">
+            <summary>
+            URI.  This value may be null based on how the UrlDetails object was initialized.
+            </summary>
+        </member>
+        <member name="P:WatsonWebserver.Core.UrlDetails.Scheme">
+            <summary>
+            Scheme name for the URI.
+            </summary>
+        </member>
+        <member name="P:WatsonWebserver.Core.UrlDetails.Host">
+            <summary>
+            Host name from the URI.
+            </summary>
+        </member>
+        <member name="P:WatsonWebserver.Core.UrlDetails.Port">
+            <summary>
+            Port number from the URI.
+            </summary>
+        </member>
         <member name="P:WatsonWebserver.Core.UrlDetails.Full">
             <summary>
             Full URL.

--- a/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
+++ b/src/WatsonWebserver.Core/WatsonWebserver.Core.xml
@@ -1587,6 +1587,22 @@
             Stop accepting new connections.
             </summary>
         </member>
+        <member name="M:WatsonWebserver.Core.WebserverBase.GetBestLocalHostName">
+            <summary>
+            Robustly retrieves and sanitizes a valid hostname for the local machine
+            by trying several strategies in order of preference.
+            This method is safe to use on all platforms, including iOS and Android.
+            </summary>
+            <returns>An RFC-compliant valid hostname, with a final fallback to "localhost".</returns>
+        </member>
+        <member name="M:WatsonWebserver.Core.WebserverBase.SanitizeHostName(System.String)">
+            <summary>
+            Converts a string into a valid RFC 1123 hostname.
+            It removes invalid characters, converts to lowercase, and handles hyphens.
+            </summary>
+            <param name="potentialName">The name to sanitize.</param>
+            <returns>A valid hostname, or null if the string contains no valid characters.</returns>
+        </member>
         <member name="T:WatsonWebserver.Core.WebserverConstants">
             <summary>
             Webserver constants.
@@ -1966,6 +1982,11 @@
             <summary>
             Debug logging settings.
             Be sure to set Events.Logger in order to receive debug messages.
+            </summary>
+        </member>
+        <member name="P:WatsonWebserver.Core.WebserverSettings.UseMachineHostname">
+            <summary>
+            When true, the machine's hostname will be used instead of the value specified in Hostname.
             </summary>
         </member>
         <member name="M:WatsonWebserver.Core.WebserverSettings.#ctor">

--- a/src/WatsonWebserver.Core/WebserverSettings.cs
+++ b/src/WatsonWebserver.Core/WebserverSettings.cs
@@ -176,6 +176,8 @@
             if (String.IsNullOrEmpty(hostname)) hostname = "localhost";
             if (port < 0) throw new ArgumentOutOfRangeException(nameof(port));
 
+            if (hostname.Equals("::")) hostname = "[::]";
+
             _Ssl.Enable = ssl;
             _Hostname = hostname;
             _Port = port;

--- a/src/WatsonWebserver.Core/WebserverSettings.cs
+++ b/src/WatsonWebserver.Core/WebserverSettings.cs
@@ -141,6 +141,22 @@
             }
         }
 
+        /// <summary>
+        /// When true, the machine's hostname will be used instead of the value specified in Hostname.
+        /// </summary>
+        public bool UseMachineHostname
+        {
+            get
+            {
+                if (Hostname == "*" || Hostname == "+") return true;
+                return _UseMachineHostname;
+            }
+            set
+            {
+                _UseMachineHostname = (Hostname == "*" || Hostname == "+") || value;
+            }
+        }
+
         #endregion
 
         #region Private-Members
@@ -152,6 +168,7 @@
         private AccessControlManager _AccessControl = new AccessControlManager(AccessControlMode.DefaultPermit);
         private DebugSettings _Debug = new DebugSettings();
         private HeaderSettings _Headers = new HeaderSettings();
+        private bool _UseMachineHostname = false;
 
         #endregion
 

--- a/src/WatsonWebserver.Lite/HttpRequest.cs
+++ b/src/WatsonWebserver.Lite/HttpRequest.cs
@@ -452,6 +452,10 @@
                         ms.Write(buffer, 0, read);
                         bytesRemaining -= read;
                     }
+                    else
+                    {
+                        throw new IOException("Connection closed before reading to the end of the stream.");
+                    }
                 }
 
                 byte[] ret = ms.ToArray();

--- a/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
+++ b/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.9</Version>
+		<Version>6.3.10</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.  Watson.Lite has no dependency on http.sys.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 		<Authors>Joel Christner</Authors>
@@ -29,7 +29,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CavemanTcp" Version="2.0.9" />
-		<PackageReference Include="Watson.Core" Version="6.3.9" />
+		<PackageReference Include="Watson.Core" Version="6.3.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
+++ b/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.10</Version>
+		<Version>6.3.12</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.  Watson.Lite has no dependency on http.sys.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 		<Authors>Joel Christner</Authors>
@@ -29,7 +29,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CavemanTcp" Version="2.0.9" />
-		<PackageReference Include="Watson.Core" Version="6.3.10" />
+		<PackageReference Include="Watson.Core" Version="6.3.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
+++ b/src/WatsonWebserver.Lite/WatsonWebserver.Lite.csproj
@@ -29,7 +29,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="CavemanTcp" Version="2.0.9" />
-		<PackageReference Include="Watson.Core" Version="6.3.12" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -46,6 +45,10 @@
 			<PackagePath></PackagePath>
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\WatsonWebserver.Core\WatsonWebserver.Core.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver.Lite/Webserver.cs
+++ b/src/WatsonWebserver.Lite/Webserver.cs
@@ -69,7 +69,10 @@
             if (settings == null) settings = new WebserverSettings(); 
 
             Settings = settings;
-            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = settings.Hostname + ":" + settings.Port;
+
+            string hostnameForHeader = settings.UseMachineHostname ? GetBestLocalHostName() : settings.Hostname;
+            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = hostnameForHeader + ":" + settings.Port;
+            
             Routes = new WebserverRoutes(Settings, defaultRoute);
 
             _Header = "[Webserver " + Settings.Prefix + "] ";

--- a/src/WatsonWebserver/WatsonWebserver.csproj
+++ b/src/WatsonWebserver/WatsonWebserver.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.9</Version>
+		<Version>6.3.10</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 		<Authors>Joel Christner</Authors>
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Watson.Core" Version="6.3.9" />
+	  <PackageReference Include="Watson.Core" Version="6.3.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver/WatsonWebserver.csproj
+++ b/src/WatsonWebserver/WatsonWebserver.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net462;net48;net6.0;net8.0</TargetFrameworks>
-		<Version>6.3.10</Version>
+		<Version>6.3.12</Version>
 		<Description>Simple, fast, async C# web server for handling REST requests with SSL support, targeted to .NET Core, .NET Standard, and .NET Framework.</Description>
 		<PackageReleaseNotes>Dependency update</PackageReleaseNotes>
 		<Authors>Joel Christner</Authors>
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Watson.Core" Version="6.3.10" />
+	  <PackageReference Include="Watson.Core" Version="6.3.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver/WatsonWebserver.csproj
+++ b/src/WatsonWebserver/WatsonWebserver.csproj
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Watson.Core" Version="6.3.12" />
+	  <ProjectReference Include="..\WatsonWebserver.Core\WatsonWebserver.Core.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/WatsonWebserver/Webserver.cs
+++ b/src/WatsonWebserver/Webserver.cs
@@ -69,7 +69,10 @@
             if (settings == null) settings = new WebserverSettings();
 
             Settings = settings;
-            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = settings.Hostname + ":" + settings.Port;
+
+            string hostnameForHeader = settings.UseMachineHostname ? GetBestLocalHostName() : settings.Hostname;
+            Settings.Headers.DefaultHeaders[WebserverConstants.HeaderHost] = hostnameForHeader + ":" + settings.Port;
+
             Routes.Default = defaultRoute;
 
             _Header = "[Webserver " + Settings.Prefix + "] ";


### PR DESCRIPTION
This PR introduces a new feature (`UseMachineHostname` in `WebserverSettings`) to provide robust control over the `Host` HTTP header and resolve a critical compatibility issue with modern .NET runtimes (.NET 9 and later).

### The Problem
Starting with .NET 9, the `System.Uri` class enforces stricter validation for hostnames according to RFC standards. This causes a `UriFormatException` when initializing the server with wildcard hostnames like `*` or `+`, as the library was incorrectly using these invalid characters to build the default `Host` HTTP header.

While existing users can work around this issue by using `0.0.0.0` to bind to all interfaces, this solution is not always intuitive and doesn't address the underlying issue of how wildcards are handled.

### The Solution: A New Feature
This feature introduces the `UseMachineHostname` boolean property to `WebserverSettings`, which provides a more elegant and powerful solution:

1.  **Automatic Hostname Resolution for Wildcards**: When the server is configured with `Hostname = "*"` or `Hostname = "+"`, the `UseMachineHostname` property is **mandatorily enabled**. This forces the server to automatically retrieve the machine's actual hostname for use in the `Host` header, while the network listener continues to correctly bind to all network interfaces. This completely resolves the compatibility issue.

2.  **Manual Control**: Developers can now manually set `UseMachineHostname = true` for **any** hostname (e.g., `localhost` or a specific IP). This gives them the flexibility to have the server's `Host` header always reflect the machine's network name, regardless of the binding configuration. By default, this behavior is disabled unless a wildcard is used.

3.  **Robust and Safe Hostname Retrieval**: The machine hostname is retrieved using a robust fallback mechanism (`Dns.GetHostName()` -> `Environment.MachineName` -> `localhost`). Furthermore, the retrieved name is sanitized to be **RFC 1123 compliant**, ensuring it is always a valid hostname, even if the device name contains spaces or special characters (e.g., "My Dev Machine" becomes "my-dev-machine").

This enhancement not only fixes a breaking change but also adds valuable functionality, giving developers more precise control over how the server identifies itself in HTTP responses.

